### PR TITLE
chore: hardcode scheduler replica count to 1

### DIFF
--- a/erpnext/templates/deployment-scheduler.yaml
+++ b/erpnext/templates/deployment-scheduler.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "erpnext.name" . }}


### PR DESCRIPTION
there's no clear way to scale up the scheduler right now, so we'll have it hardcoded to 1. this will prevent it from being scaled while setting a replicaCount value inside values.yaml