### PR TITLE
fix: mount assets directory on migrate-job

### DIFF
--- a/erpnext/templates/job-migrate-sites.yaml
+++ b/erpnext/templates/job-migrate-sites.yaml
@@ -42,8 +42,12 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+          - name: assets-cache
+            mountPath: /home/frappe/frappe-bench/sites/assets
       restartPolicy: Never
       volumes:
+        - name: assets-cache
+          emptyDir: {}
         - name: sites-dir
           persistentVolumeClaim:
             {{- if .Values.persistence.existingClaim }}


### PR DESCRIPTION
required to build assets for website theme, which gets generated on migrate