### PR TITLE
feat:Add a helper function to allow for dynamic mariadbHost override

### DIFF
--- a/erpnext/templates/_helpers.tpl
+++ b/erpnext/templates/_helpers.tpl
@@ -69,6 +69,30 @@ Create redis host name
 {{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Gets the mariadb host name
+*/}}
 {{- define "erpnext.mariadbHost" -}}
 {{ .Values.mariadbHost }}
+{{- end -}}
+
+{{/*
+Gets the redis socketio host name
+*/}}
+{{- define "erpnext.redisSocketIOHost" -}}
+{{ .Values.redisSocketIOHost }}
+{{- end -}}
+
+{{/*
+Gets the redis queue host name
+*/}}
+{{- define "erpnext.redisQueueHost" -}}
+{{ .Values.redisQueueHost }}
+{{- end -}}
+
+{{/*
+Gets the redis cache host name
+*/}}
+{{- define "erpnext.redisCacheHost" -}}
+{{ .Values.redisCacheHost }}
 {{- end -}}

--- a/erpnext/templates/_helpers.tpl
+++ b/erpnext/templates/_helpers.tpl
@@ -68,3 +68,7 @@ Create redis host name
 {{- define "redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "erpnext.mariadbHost" -}}
+{{ .Values.mariadbHost }}
+{{- end -}}

--- a/erpnext/templates/deployment-erpnext.yaml
+++ b/erpnext/templates/deployment-erpnext.yaml
@@ -75,22 +75,22 @@ spec:
             - name: "MARIADB_HOST"
               value: {{ required "A valid .Values.mariadbHost entry required!" (include "erpnext.mariadbHost" .) }}
             - name: "REDIS_QUEUE"
-              {{- if eq .Values.redisQueueHost "" }}
+              {{- if eq (include "erpnext.redisQueueHost" .) "" }}
               value: {{ include "erpnext.fullname" . }}-redis-queue:{{ .Values.redisQueueService.port }}
               {{- else }}
-              value: {{ .Values.redisQueueHost }}
+              value: {{ include "erpnext.redisQueueHost" . }}
               {{- end }}
             - name: "REDIS_CACHE"
-              {{- if eq .Values.redisCacheHost "" }}
+              {{- if eq (include "erpnext.redisCacheHost" .) "" }}
               value: {{ include "erpnext.fullname" . }}-redis-cache:{{ .Values.redisCacheService.port }}
               {{- else }}
-              value: {{ .Values.redisCacheHost }}
+              value: {{ include "erpnext.redisCacheHost" . }}
               {{- end }}
             - name: "REDIS_SOCKETIO"
-              {{- if eq .Values.redisSocketIOHost "" }}
+              {{- if eq (include "erpnext.redisSocketIOHost" .) "" }}
               value: {{ include "erpnext.fullname" . }}-redis-socketio:{{ .Values.redisSocketIOService.port }}
               {{- else }}
-              value: {{ .Values.redisSocketIOHost }}
+              value: {{ include "erpnext.redisSocketIOHost" . }}
               {{- end }}
             - name: "SOCKETIO_PORT"
               value: {{ .Values.socketIOPort | quote }}

--- a/erpnext/templates/deployment-erpnext.yaml
+++ b/erpnext/templates/deployment-erpnext.yaml
@@ -73,7 +73,7 @@ spec:
           imagePullPolicy: {{ .Values.pythonImage.pullPolicy }}
           env:
             - name: "MARIADB_HOST"
-              value: {{ required "A valid .Values.mariadbHost entry required!" .Values.mariadbHost }}
+              value: {{ required "A valid .Values.mariadbHost entry required!" (include "erpnext.mariadbHost" .) }}
             - name: "REDIS_QUEUE"
               {{- if eq .Values.redisQueueHost "" }}
               value: {{ include "erpnext.fullname" . }}-redis-queue:{{ .Values.redisQueueService.port }}

--- a/erpnext/templates/deployment-redis-cache.yaml
+++ b/erpnext/templates/deployment-redis-cache.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.redisCacheHost ""}}
+{{- if eq (include "erpnext.redisCacheHost" .) ""}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/erpnext/templates/deployment-redis-queue.yaml
+++ b/erpnext/templates/deployment-redis-queue.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.redisQueueHost ""}}
+{{- if eq (include "erpnext.redisQueueHost" .) ""}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/erpnext/templates/deployment-redis-socketio.yaml
+++ b/erpnext/templates/deployment-redis-socketio.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.redisSocketIOHost ""}}
+{{- if eq (include "erpnext.redisSocketIOHost" .) ""}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/erpnext/templates/redis-cache-service.yaml
+++ b/erpnext/templates/redis-cache-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.redisCacheHost ""}}
+{{- if eq (include "erpnext.redisCacheHost" .) ""}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/erpnext/templates/redis-queue-service.yaml
+++ b/erpnext/templates/redis-queue-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.redisQueueHost ""}}
+{{- if eq (include "erpnext.redisQueueHost" .) ""}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/erpnext/templates/redis-socketio-service.yaml
+++ b/erpnext/templates/redis-socketio-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.redisSocketIOHost ""}}
+{{- if eq (include "erpnext.redisSocketIOHost" .) ""}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
I'm currently deploying this chart alongside a mariadb galera cluster chart, and I would like to bundle both of the charts under an umbrella chart. 
But I want to be able to use a dynamic name for the mariadb host, the one the cluster creates, that is composed of the release and chart name. 

Right now this is not possible due to helm restrictions of dynamic values in the values.yaml file.
With this approach, we could be able to override the helper in the umbrella chart, and defer the naming to the helper used in the mariadb chart. 

This helper would normally return the mariadbHost set in the values file, so this is not a breaking change.