### PR TITLE
Two small fixes

### DIFF
--- a/erpnext/templates/deployment-erpnext.yaml
+++ b/erpnext/templates/deployment-erpnext.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "erpnext.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.worker.enabled }}
       initContainers:
         - name: frappe-bench-ownership
           image: quay.io/libpod/alpine:3.2

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -24,7 +24,7 @@ redis:
     repository: bitnami/redis
     tag: 5.0.10-debian-10-r105
     pullPolicy: IfNotPresent
-    extraEnv:
+  extraEnv:
     - name: ALLOW_EMPTY_PASSWORD
       value: "yes"
 

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -105,7 +105,7 @@ persistence:
     # storageClass: "nfs"
 
 volumePermissions:
-  enabled: no
+  enabled: false
 
 resources: {}
   # If you do want to specify resources, uncomment the following


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Following https://github.com/frappe/helm/pull/69, I found there are a couple of small fixes required

> Explain the **details** for making this change. What existing problem does the pull request solve?

The two fixes are:
- This helm chart deploys redis wihout password by default. Bitnami's redis image runs in safe mode by default and requires a password. There is a small indentation issue that wasn't applying right env variable. I saw that in the latest changes of this chart, the command of the redis containers is overriden. Maybe this makes that override redundant too?
- With new persistence classes, there was a conditional that would always be false
