### PR TITLE
feat: use custom nginx config via values.yaml

### DIFF
--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 | `nginxImage.repository`          | Frappe/ERPNext Nginx Docker image registry                   | `frappe/erpnext-nginx`          |
 | `nginxImage.tag`                 | Frappe/ERPNext Nginx Docker image tag                        | Latest Stable Release           |
 | `nginxImage.pullPolicy`          | Frappe/ERPNext Nginx Docker image pullPolicy                 | `IfNotPresent`                  |
+| `nginxImage.nginxConfig`         | Frappe/ERPNext Nginx Docker image custom default.conf        | `nil`                           |
 | `pythonImage.repository`         | Frappe/ERPNext Python Docker image registry                  | `frappe/erpnext-worker`         |
 | `pythonImage.tag`                | Frappe/ERPNext Python Docker image tag                       | Latest Stable Release           |
 | `pythonImage.pullPolicy`         | Frappe/ERPNext Python Docker image pullPolicy                | `IfNotPresent`                  |
@@ -71,7 +72,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 | `redis.image.repository`         | Redis Docker image registry                                  | `bitnami/redis`                 |
 | `redis.image.tag`                | Redis Docker image tag                                       | Latest Stable Release           |
 | `redis.image.pullPolicy`         | Redis Docker image pullPolicy                                | `IfNotPresent`                  |
-| `redis.extraEnv`                 | Redis Extra Environment Variables                            | `ALLOW_EMPTY_PASSWORD=true`                            |
+| `redis.extraEnv`                 | Redis Extra Environment Variables                            | `ALLOW_EMPTY_PASSWORD=true`     |
 | `frappePyPort`                   | Frappe/ERPNext Python Gunicorn Worker Port                   | `8000`                          |
 | `socketIOPort`                   | Frappe/ERPNext SocketIO Port                                 | `9000`                          |
 | `upstreamRealIPAddress`          | Trusted address (or ip range) of upstream proxy servers      | `127.0.0.1`                     |
@@ -89,7 +90,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 | `persistence.logs.enable`        | Creates PVC for logs volume with helm release name           | `true`                          |
 | `persistence.logs.size`          | Creates PVC for logs volume with size                        | `8Gi`                           |
 | `persistence.logs.storageClass`  | StorageClass with RWX, Required if PVC is created            | `nil`                           |
-| `volumePermissions.enabled`      | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`
+| `volumePermissions.enabled`      | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`    |
 
 The above parameters map to the env variables defined in [frappe_docker](http://github.com/frappe/frappe_docker). For more information please refer to the [frappe_docker](http://github.com/frappe/frappe_docker) images documentation.
 

--- a/erpnext/templates/configmap-nginx-config.yaml
+++ b/erpnext/templates/configmap-nginx-config.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.nginxImage.nginxConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "erpnext.fullname" . }}-nginx-config
+  labels:
+    {{- include "erpnext.labels" . | nindent 4 }}
+data:
+  default.conf: {{ .Values.nginxImage.nginxConfig | quote }}
+{{- end }}

--- a/erpnext/templates/deployment-erpnext.yaml
+++ b/erpnext/templates/deployment-erpnext.yaml
@@ -50,6 +50,10 @@ spec:
             mountPath: /assets
           - name: sites-dir
             mountPath: /var/www/html/sites
+          {{- if .Values.nginxImage.nginxConfig }}
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d
+          {{- end }}
           imagePullPolicy: {{ .Values.nginxImage.pullPolicy }}
           env:
             - name: "FRAPPE_PY"
@@ -72,6 +76,10 @@ spec:
             - name: "UPSTREAM_REAL_IP_HEADER"
               value: {{ .Values.upstreamRealIPHeader }}
               {{- end }}
+            {{- if .Values.nginxImage.nginxConfig }}
+            - name: "SKIP_NGINX_TEMPLATE_GENERATION"
+              value: "1"
+            {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -152,6 +160,11 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.nginxImage.nginxConfig }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "erpnext.fullname" . }}-nginx-config
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -8,6 +8,8 @@ nginxImage:
   repository: frappe/erpnext-nginx
   tag: v13.0.1
   pullPolicy: IfNotPresent
+  # nginxConfig: |
+  #   # custom /etc/nginx/conf.d/default.conf
 
 pythonImage:
   repository: frappe/erpnext-worker


### PR DESCRIPTION
Allow custom default.conf.
Use to add sidecars, custom apps and reverse proxy with frappe/erpnext site.
