### PR TITLE
Allow user to set custom port for MariaDB

### DIFF
--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 | `upstreamRealIPRecursive`             | Recursive look for upstream proxy server for real IP if `on` | `off`                           |
 | `upstreamRealIPHeader`                | Header name sent by your upstream proxy server               | `X-Forwarded-For`               |
 | `mariadbHost`                         | MariaDB Host to connect (Required)                           | `nil`                           |
+| `mariadbPort`                         | MariaDB Port to connect (Optional)                           | `3306`                          |
 | `redisQueueHost`                      | Queue Redis Host to connect (Optional)                       | `nil`                           |
 | `redisCacheHost`                      | Cache Redis Host to connect (Optional)                       | `nil`                           |
 | `redisSocketIOHost`                   | Socket IO Redis Host to connect (Optional)                   | `nil`                           |

--- a/erpnext/templates/deployment-erpnext.yaml
+++ b/erpnext/templates/deployment-erpnext.yaml
@@ -101,6 +101,8 @@ spec:
           env:
             - name: "MARIADB_HOST"
               value: {{ required "A valid .Values.mariadbHost entry required!" (include "erpnext.mariadbHost" .) }}
+            - name: "DB_PORT"
+              value: {{ .Values.mariadbPort | quote }}
             - name: "REDIS_QUEUE"
               {{- if eq (include "erpnext.redisQueueHost" .) "" }}
               value: {{ include "erpnext.fullname" . }}-redis-queue:{{ .Values.redisQueueService.port }}

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -40,6 +40,7 @@ socketIOPort: "9000"
 
 # Python Image Env Variables
 # mariadbHost: "mariadb.mariadb.svc.cluster.local"
+mariadbPort: "3306"
 
 redisQueueHost: ""
 redisCacheHost: ""


### PR DESCRIPTION
Even tough it is possible to use a different MariaDB host it is not possible to alter the port used. This however is necessary for a lot of Cloud DB provider.
