### PR TITLE
Change containerPort of socketio

### DIFF
--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.socketIOImage.pullPolicy }}
           ports:
             - name: http
-              containerPort: 9000
+              containerPort: 8000
               protocol: TCP
           livenessProbe:
             tcpSocket:


### PR DESCRIPTION
I'm not sure if it's something in my config, but it seems to me that the `containerPort` for socketio is not right.

When the container with image `frappe/frappe-socketio:v13.7.0` starts, I get this in the logs: `listening on *: 8000`

That being the case, no traffic will ever reach the container, since the `containerPort` is set to 9000

Changing it to 8000 fixes it in my case

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
