### PR TITLE
Update node names for redundant mariadb installs; Extend create site …

### DIFF
--- a/erpnext/templates/job-configure-bench.yaml
+++ b/erpnext/templates/job-configure-bench.yaml
@@ -56,7 +56,11 @@ spec:
         env:
           - name: DB_HOST
             {{- if .Values.mariadb.enabled }}
+            {{- if eq .Values.mariadb.architecture "replication" }}
+            value: {{ .Release.Name }}-mariadb-primary
+            {{- else }}
             value: {{ .Release.Name }}-mariadb
+            {{- end }}
             {{- else }}
             value: {{ .Values.dbHost }}
             {{- end }}

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -46,7 +46,7 @@ spec:
               do
                 echo "Waiting for common_site_config.json to be created";
                 sleep 5;
-                if (( `date +%s`-start > 120 )); then
+                if (( `date +%s`-start > 600 )); then
                   echo "could not find common_site_config.json with required keys";
                   exit 1
                 fi
@@ -93,7 +93,11 @@ spec:
             {{- else if .Values.postgresql.enabled }}
             value: {{ .Release.Name }}-postgresql
             {{- else if .Values.mariadb.enabled }}
+            {{- if eq .Values.mariadb.architecture "replication" }}
+            value: {{ .Release.Name }}-mariadb-primary
+            {{- else }}
             value: {{ .Release.Name }}-mariadb
+            {{- end }}
             {{- else }}
             value: "{{ .Values.dbHost }}"
             {{- end }}

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -158,7 +158,11 @@ worker:
         - -c
         - echo "Ping backing services";
         {{- if .Values.mariadb.enabled }}
+        {{- if eq .Values.mariadb.architecture "replication" }}
+        - wait-for-it {{ .Release.Name }}-mariadb-primary:{{ .Values.mariadb.primary.service.ports.mysql }} -t 1;
+        {{- else }}
         - wait-for-it {{ .Release.Name }}-mariadb:{{ .Values.mariadb.primary.service.ports.mysql }} -t 1;
+        {{- end }}
         {{- else if .Values.dbHost }}
         - wait-for-it {{ .Values.dbHost }}:{{ .Values.mariadb.primary.service.ports.mysql }} -t 1;
         {{- end }}


### PR DESCRIPTION
…timeout to 10 minutes

When deploying a redundant mariadb configuration, the node names are -mariadb-primary and -mariadb-secondary, and the existing charts assume just -mariadb in a single node configuration. This checks for a redundant install setting and sets the node names accordingly.

One minor script update timing for the "create site" job was updated from 2 minutes to 10 minutes, to provide the K8 install enough time to configure redundant mariadb nodes.
