### PR TITLE
Add populate-assets initContainers and assets-cache volumes to workers

### DIFF
--- a/erpnext/templates/deployment-worker-default.yaml
+++ b/erpnext/templates/deployment-worker-default.yaml
@@ -23,10 +23,28 @@ spec:
       serviceAccountName: {{ template "erpnext.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-    {{- if .Values.worker.default.initContainers }}
       initContainers:
+        - name: populate-assets
+          {{- if .Values.worker.default.envVars }}
+          env:
+            {{- toYaml .Values.worker.default.envVars | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          command:
+            - cp
+            - -fR
+          args:
+            - /usr/share/nginx/html/assets
+            - /home/frappe/frappe-bench/sites
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: assets-cache
+              mountPath: /home/frappe/frappe-bench/sites/assets
+      {{- if .Values.worker.default.initContainers }}
         {{- toYaml .Values.worker.default.initContainers | nindent 8 }}
-    {{- end }}
+      {{- end }}
       containers:
         - name: default
           {{- if .Values.worker.default.envVars }}
@@ -57,6 +75,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
+          - name: assets-cache
+            mountPath: /home/frappe/frappe-bench/sites/assets
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
@@ -65,6 +85,8 @@ spec:
         {{- toYaml .Values.worker.default.sidecars | nindent 8 }}
       {{- end }}
       volumes:
+        - name: assets-cache
+          emptyDir: {}
         - name: sites-dir
           {{- if .Values.persistence.worker.enabled }}
           persistentVolumeClaim:

--- a/erpnext/templates/deployment-worker-long.yaml
+++ b/erpnext/templates/deployment-worker-long.yaml
@@ -23,10 +23,28 @@ spec:
       serviceAccountName: {{ template "erpnext.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-    {{- if .Values.worker.long.initContainers }}
       initContainers:
+        - name: populate-assets
+          {{- if .Values.worker.long.envVars }}
+          env:
+            {{- toYaml .Values.worker.long.envVars | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          command:
+            - cp
+            - -fR
+          args:
+            - /usr/share/nginx/html/assets
+            - /home/frappe/frappe-bench/sites
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: assets-cache
+              mountPath: /home/frappe/frappe-bench/sites/assets
+      {{- if .Values.worker.long.initContainers }}
         {{- toYaml .Values.worker.long.initContainers | nindent 8 }}
-    {{- end }}
+      {{- end }}
       containers:
         - name: long
           {{- if .Values.worker.long.envVars }}
@@ -57,6 +75,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
+          - name: assets-cache
+            mountPath: /home/frappe/frappe-bench/sites/assets
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
@@ -65,6 +85,8 @@ spec:
         {{- toYaml .Values.worker.long.sidecars | nindent 8 }}
       {{- end }}
       volumes:
+        - name: assets-cache
+          emptyDir: {}
         - name: sites-dir
           {{- if .Values.persistence.worker.enabled }}
           persistentVolumeClaim:

--- a/erpnext/templates/deployment-worker-short.yaml
+++ b/erpnext/templates/deployment-worker-short.yaml
@@ -23,10 +23,28 @@ spec:
       serviceAccountName: {{ template "erpnext.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-    {{- if .Values.worker.short.initContainers }}
       initContainers:
+        - name: populate-assets
+          {{- if .Values.worker.short.envVars }}
+          env:
+            {{- toYaml .Values.worker.short.envVars | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          command:
+            - cp
+            - -fR
+          args:
+            - /usr/share/nginx/html/assets
+            - /home/frappe/frappe-bench/sites
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: assets-cache
+              mountPath: /home/frappe/frappe-bench/sites/assets      
+      {{- if .Values.worker.short.initContainers }}
         {{- toYaml .Values.worker.short.initContainers | nindent 8 }}
-    {{- end }}
+      {{- end }}
       containers:
         - name: short
           {{- if .Values.worker.short.envVars }}
@@ -57,6 +75,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
+          - name: assets-cache
+            mountPath: /home/frappe/frappe-bench/sites/assets
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
@@ -65,6 +85,8 @@ spec:
         {{- toYaml .Values.worker.short.sidecars | nindent 8 }}
       {{- end }}
       volumes:
+        - name: assets-cache
+          emptyDir: {}
         - name: sites-dir
           {{- if .Values.persistence.worker.enabled }}
           persistentVolumeClaim:


### PR DESCRIPTION
Adds an assets initContainer and related assets-cache volume to long,short, and default workers. This resolves various email send/receive issues associated with an empty assets directory in the workers. Example: https://discuss.erpnext.com/t/no-documents-created-with-email/93167/3
