### PR TITLE
[conf-bench-job] Don't change permissions on container filesystem

### DIFF
--- a/erpnext/templates/job-configure-bench.yaml
+++ b/erpnext/templates/job-configure-bench.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['sh', '-c']
         args:
-          - chown -R "{{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsUser }}" /home/frappe/frappe-bench
+          - chown -R "{{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsUser }}" /home/frappe/frappe-bench/sites /home/frappe/frappe-bench/logs
         resources:
           {{- toYaml .Values.jobs.configure.resources | nindent 10 }}
         securityContext:


### PR DESCRIPTION
Fixes #169

> Explain the **details** for making this change. What existing problem does the pull request solve?

Instead of running a chown on the whole `/home/frappe/frappe-bench` folder in the fix-volume init container, only run a chown on the volumes itself.