### PR TITLE
fix: socketio deployment tolerations, affinity

### DIFF
--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -87,11 +87,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.socketio.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with .Values.socketio.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
to use taints and tolerations to utilize spot nodes

```
socketio:
  replicaCount: 1
  .....
  tolerations:
    - key: "dedicated"
      operator: "Equal"
      value: "preemptible-np-erpnext"
      effect: "NoSchedule"
  ....
```