### PR TITLE
Correct nindent to 10 for envVars

### DIFF
--- a/erpnext/templates/job-configure-bench.yaml
+++ b/erpnext/templates/job-configure-bench.yaml
@@ -88,7 +88,7 @@ spec:
             value: {{ index .Values "redis-queue" "host" }}
             {{- end }}
           {{- if .Values.jobs.configure.envVars }}
-            {{- toYaml .Values.jobs.configure.envVars | nindent 12 }}
+            {{- toYaml .Values.jobs.configure.envVars | nindent 10 }}
           {{- end }}
           - name: SOCKETIO_PORT
             value: {{ .Values.socketio.service.port | quote }}


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Correct nindent size for `envVars`

Example values:

```
jobs:
  configure:
    enabled: true
    envVars:
    - name: ETRA_VAR_1
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: my-password
```

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
