### PR TITLE
Wait until the database is reachable in job-create-site

### DIFF
--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -87,12 +87,12 @@ spec:
 
             bench_output=$(bench new-site ${SITE_NAME} \
               --no-mariadb-socket \
-              --db-type=$(DB_TYPE) \
-              --db-host=$(DB_HOST) \
-              --db-port=$(DB_PORT) \
-              --admin-password=$(ADMIN_PASSWORD) \
-              --mariadb-root-username=$(DB_ROOT_USER) \
-              --mariadb-root-password=$(DB_ROOT_PASSWORD) \
+              --db-type=${DB_TYPE} \
+              --db-host=${DB_HOST} \
+              --db-port=${DB_PORT} \
+              --admin-password=${ADMIN_PASSWORD} \
+              --mariadb-root-username=${DB_ROOT_USER} \
+              --mariadb-root-password=${DB_ROOT_PASSWORD} \
               {{- if .Values.jobs.createSite.installApps }}
                 {{- range .Values.jobs.createSite.installApps }}
                   --install-app={{ . }} \

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -101,7 +101,7 @@ spec:
             {{- if .Values.jobs.createSite.forceCreate }}
               --force \
             {{- end }}
-             | tee /dev/tty);
+             | tee /dev/stderr);
 
             bench_exit_status=$?;
 

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -36,6 +36,33 @@ spec:
                 fi
               done;
               echo "sites/common_site_config.json found";
+
+              echo "Waiting for database to be reachable...";
+              wait-for-it -t 180 $(DB_HOST):$(DB_PORT);
+              echo "Database is reachable.";
+          env:
+            - name: "DB_HOST"
+              {{- if .Values.postgresql.host }}
+              value: {{ .Values.postgresql.host }}
+              {{- else if .Values.postgresql.enabled }}
+              value: {{ .Release.Name }}-postgresql
+              {{- else if .Values.mariadb.enabled }}
+              {{- if eq .Values.mariadb.architecture "replication" }}
+              value: {{ .Release.Name }}-mariadb-primary
+              {{- else }}
+              value: {{ .Release.Name }}-mariadb
+              {{- end }}
+              {{- else }}
+              value: "{{ .Values.dbHost }}"
+              {{- end }}
+            - name: "DB_PORT"
+              {{- if .Values.dbPort }}
+              value: {{ .Values.dbPort | quote }}
+              {{- else if .Values.postgresql.enabled }}
+              value: {{ .Values.postgresql.primary.service.ports.postgresql | quote }}
+              {{- else }}
+              value: {{ .Values.mariadb.primary.service.ports.mysql | quote }}
+              {{- end }}
           resources:
             {{- toYaml .Values.jobs.createSite.resources | nindent 12 }}
           securityContext:
@@ -50,6 +77,8 @@ spec:
         command: ["bash", "-c"]
         args:
           - >
+            set -e;
+
             bench new-site $(SITE_NAME)
             --no-mariadb-socket
             --db-type=$(DB_TYPE)

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -101,7 +101,7 @@ spec:
             {{- if .Values.jobs.createSite.forceCreate }}
               --force \
             {{- end }}
-            );
+             | tee);
 
             bench_exit_status=$?;
 

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -93,26 +93,27 @@ spec:
               --mariadb-root-password=$(DB_ROOT_PASSWORD) \
               {{- if .Values.jobs.createSite.installApps }}
                 {{- range .Values.jobs.createSite.installApps }}
-                  --install-app={{ . }}
+                  --install-app={{ . }} \
                 {{- end }}
               {{- end }}
                 {{- if .Values.jobs.createSite.forceCreate }}
-                  --force
+                  --force \
                 {{- end }} 2>&1)
+              ;
 
-            bench_exit_status=$?
+            bench_exit_status=$?;
 
             if [ $bench_exit_status -ne 0 ]; then
                 # Don't consider the case "site already exists" an error.
                 if [[ $bench_output == *"already exists"* ]]; then
-                    echo "Site already exists, continuing..."
+                    echo "Site already exists, continuing...";
                 else
                     echo "An error occurred in bench new-site: $bench_output"
-                    exit $bench_exit_status
+                    exit $bench_exit_status;
                 fi
             fi
  
-            ;set -e
+            set -e;
 
             ;rm -f currentsite.txt
         env:

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -83,6 +83,8 @@ spec:
         command: ["bash", "-c"]
         args:
           - >
+            set -x;
+
             bench_output=$(bench new-site $(SITE_NAME) \
               --no-mariadb-socket \
               --db-type=$(DB_TYPE) \

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -101,7 +101,7 @@ spec:
             {{- if .Values.jobs.createSite.forceCreate }}
               --force \
             {{- end }}
-             | tee >(cat));
+             | tee /dev/tty);
 
             bench_exit_status=$?;
 

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -83,24 +83,37 @@ spec:
         command: ["bash", "-c"]
         args:
           - >
-            set -e;
+            bench_output=$(bench new-site $(SITE_NAME) \
+              --no-mariadb-socket \
+              --db-type=$(DB_TYPE) \
+              --db-host=$(DB_HOST) \
+              --db-port=$(DB_PORT) \
+              --admin-password=$(ADMIN_PASSWORD) \
+              --mariadb-root-username=$(DB_ROOT_USER) \
+              --mariadb-root-password=$(DB_ROOT_PASSWORD) \
+              {{- if .Values.jobs.createSite.installApps }}
+                {{- range .Values.jobs.createSite.installApps }}
+                  --install-app={{ . }}
+                {{- end }}
+              {{- end }}
+                {{- if .Values.jobs.createSite.forceCreate }}
+                  --force
+                {{- end }} 2>&1)
 
-            bench new-site $(SITE_NAME)
-            --no-mariadb-socket
-            --db-type=$(DB_TYPE)
-            --db-host=$(DB_HOST)
-            --db-port=$(DB_PORT)
-            --admin-password=$(ADMIN_PASSWORD)
-            --mariadb-root-username=$(DB_ROOT_USER)
-            --mariadb-root-password=$(DB_ROOT_PASSWORD)
-        {{- if .Values.jobs.createSite.installApps }}
-          {{- range .Values.jobs.createSite.installApps }}
-            --install-app={{ . }}
-          {{- end }}
-        {{- end }}
-          {{- if .Values.jobs.createSite.forceCreate }}
-            --force
-          {{- end }}
+            bench_exit_status=$?
+
+            if [ $bench_exit_status -ne 0 ]; then
+                # Don't consider the case "site already exists" an error.
+                if [[ $bench_output == *"already exists"* ]]; then
+                    echo "Site already exists, continuing..."
+                else
+                    echo "An error occurred in bench new-site: $bench_output"
+                    exit $bench_exit_status
+                fi
+            fi
+ 
+            ;set -e
+
             ;rm -f currentsite.txt
         env:
           - name: "SITE_NAME"

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -85,7 +85,7 @@ spec:
           - >
             set -x;
 
-            bench_output=$(bench new-site $(SITE_NAME) \
+            bench_output=$(bench new-site ${SITE_NAME} \
               --no-mariadb-socket \
               --db-type=$(DB_TYPE) \
               --db-host=$(DB_HOST) \

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -101,7 +101,7 @@ spec:
             {{- if .Values.jobs.createSite.forceCreate }}
               --force \
             {{- end }}
-             | tee);
+             | tee >(cat));
 
             bench_exit_status=$?;
 

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
   annotations:
-  {{- if .Values.jobs.createSite.annotations }}
-  {{- range .Values.jobs.createSite.annotations }}
-    {{ . }}
-  {{- end }}
-  {{- end }}
+{{- with .Values.jobs.createSite.annotations }}
+{{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
 spec:
   backoffLimit: {{ .Values.jobs.createSite.backoffLimit }}
   template:

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ template "erpnext.fullname" . }}-new-site-{{ now | date "20060102150405" }}
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
+  annotations:
+  {{- if .Values.jobs.createSite.annotations }}
+  {{- range .Values.jobs.createSite.annotations }}
+    {{ . }}
+  {{- end }}
+  {{- end }}
 spec:
   backoffLimit: {{ .Values.jobs.createSite.backoffLimit }}
   template:

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -93,14 +93,15 @@ spec:
               --admin-password=${ADMIN_PASSWORD} \
               --mariadb-root-username=${DB_ROOT_USER} \
               --mariadb-root-password=${DB_ROOT_PASSWORD} \
-              {{- if .Values.jobs.createSite.installApps }}
-                {{- range .Values.jobs.createSite.installApps }}
-                  --install-app={{ . }} \
-                {{- end }}
+            {{- if .Values.jobs.createSite.installApps }}
+              {{- range .Values.jobs.createSite.installApps }}
+              --install-app={{ . }} \
               {{- end }}
-                {{- if .Values.jobs.createSite.forceCreate }}
-                  --force \
-                {{- end }});
+            {{- end }}
+            {{- if .Values.jobs.createSite.forceCreate }}
+              --force \
+            {{- end }}
+            );
 
             bench_exit_status=$?;
 

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -100,7 +100,7 @@ spec:
               {{- end }}
                 {{- if .Values.jobs.createSite.forceCreate }}
                   --force \
-                {{- end }} 2>&1);
+                {{- end }});
 
             bench_exit_status=$?;
 

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -116,7 +116,7 @@ spec:
  
             set -e;
 
-            ;rm -f currentsite.txt
+            rm -f currentsite.txt
         env:
           - name: "SITE_NAME"
             value: "{{ .Values.jobs.createSite.siteName }}"

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -98,8 +98,7 @@ spec:
               {{- end }}
                 {{- if .Values.jobs.createSite.forceCreate }}
                   --force \
-                {{- end }} 2>&1)
-              ;
+                {{- end }} 2>&1);
 
             bench_exit_status=$?;
 


### PR DESCRIPTION
- Wait for the database in the init container to become reachable before trying to create a new site. Without waiting there is a race condition that pops up occasionally which makes the creation of the site fail.

- Exit the main container of the job if any error happens by adding `set -e`. At the moment the container exists with the return code 0, even if the site was not successfully created. This is because the last command in the entrypoint is an `rm -f` which always exits with 0.

https://github.com/frappe/helm/blob/275c25f46337fe0bc4220c412e5892c26522cd7a/erpnext/templates/job-create-site.yaml#L104

Related to https://github.com/frappe/helm/issues/205

Actually exiting the container with the correct exit code is enough to fix the issue if the job is configured to restart if failed. Though, waiting for the database in the beginning is cleaner.