### PR TITLE
fix: quote env var in deployment

### DIFF
--- a/erpnext/templates/deployment-nginx.yaml
+++ b/erpnext/templates/deployment-nginx.yaml
@@ -51,7 +51,7 @@ spec:
             - name: "FRAPPE_SITE_NAME_HEADER"
               value: {{ .Values.nginx.environment.frappeSiteNameHeader }}
             - name: "PROXY_READ_TIMEOUT"
-              value: {{ .Values.nginx.environment.proxyReadTimeout }}
+              value: {{ .Values.nginx.environment.proxyReadTimeout | quote }}
             - name: "CLIENT_MAX_BODY_SIZE"
               value: {{ .Values.nginx.environment.clientMaxBodySize }}
           {{- if .Values.nginx.envVars }}

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -29,7 +29,7 @@ nginx:
     upstreamRealIPRecursive: "off"
     upstreamRealIPHeader: "X-Forwarded-For"
     frappeSiteNameHeader: "$host"
-    proxyReadTimeout: 120
+    proxyReadTimeout: "120"
     clientMaxBodySize: "50m"
   livenessProbe:
     tcpSocket:


### PR DESCRIPTION
Fix for error

```
Error: UPGRADE FAILED: cannot patch "frappe-bench-erpnext-nginx" with kind Deployment:  "" is invalid: patch: Invalid value: 
...
json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```