### PR TITLE
update default image to use full qualifiers

### DIFF
--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -12,7 +12,7 @@
 # dbExistingSecretPasswordKey: "password"
 
 image:
-  repository: frappe/erpnext
+  repository: docker.io/frappe/erpnext
   tag: v15.80.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
some k8s setups use cri-o instead of conrainerd, so the image resolve policy is a bit strict, which doesn't allow short names in image name. this adjust to use the longer name.