### PR TITLE
feat: allow HPA to control replicas by conditionally omitting replicas

### DIFF
--- a/erpnext/templates/deployment-gunicorn.yaml
+++ b/erpnext/templates/deployment-gunicorn.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.worker.gunicorn.autoscaler.enabled }}
+  {{- if not .Values.worker.gunicorn.autoscaling.enabled }}
   replicas: {{ .Values.worker.gunicorn.replicaCount }}
   {{- end }}
   selector:

--- a/erpnext/templates/deployment-nginx.yaml
+++ b/erpnext/templates/deployment-nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.worker.nginx.autoscaler.enabled }}
+  {{- if not .Values.nginx.autoscaling.enabled }}
   replicas: {{ .Values.nginx.replicaCount }}
   {{- end }}
   selector:

--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.worker.socketio.autoscaler.enabled }}
+  {{- if not .Values.socketio.autoscaling.enabled }}
   replicas: {{ .Values.socketio.replicaCount }}
   {{- end }}
   selector:

--- a/erpnext/templates/deployment-worker-default.yaml
+++ b/erpnext/templates/deployment-worker-default.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.worker.default.autoscaler.enabled }}
+  {{- if not .Values.worker.default.autoscaling.enabled }}
   replicas: {{ .Values.worker.default.replicaCount }}
   {{- end }}
   selector:

--- a/erpnext/templates/deployment-worker-long.yaml
+++ b/erpnext/templates/deployment-worker-long.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.worker.long.autoscaler.enabled }}
+  {{- if not .Values.worker.long.autoscaling.enabled }}
   replicas: {{ .Values.worker.long.replicaCount }}
   {{- end }}
   selector:

--- a/erpnext/templates/deployment-worker-short.yaml
+++ b/erpnext/templates/deployment-worker-short.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "erpnext.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.worker.short.autoscaler.enabled }}
+  {{- if not .Values.worker.short.autoscaling.enabled }}
   replicas: {{ .Values.worker.short.replicaCount }}
   {{- end }}
   selector:


### PR DESCRIPTION
This change updates the Deployment templates for gunicorn, nginx, socketio, and all worker types to conditionally omit the replicas field when autoscaling.enabled=true.

Previously, ArgoCD would detect a conflict between the Helm-rendered replicas value and the replicas dynamically managed by the HorizontalPodAutoscaler (HPA), leading to constant OutOfSync status and undesired scaling behavior.

With this change:
- HPA can fully control pod scaling without ArgoCD overwriting .spec.replicas.
- Deployments still support static scaling when autoscaling.enabled=false.
- Prevents conflicts and unnecessary Helm syncs in ArgoCD.
