### PR TITLE
fix(jobs): replaced deprecated command argument `--no-mariadb-socket` by the recommanded `--mariadb-user-host-login-scope='%'` (wildcard)

### DIFF
--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -90,9 +90,9 @@ spec:
         args:
           - >
             set -x;
-
+            
             bench_output=$(bench new-site ${SITE_NAME} \
-              --no-mariadb-socket \
+              --mariadb-user-host-login-scope='%' \
               --db-type=${DB_TYPE} \
               --db-host=${DB_HOST} \
               --db-port=${DB_PORT} \


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The  `create-site` uses the deprecated `--no-mariadb-socket` command line argument.
Using the recommended `--mariadb-user-host-login-scope='%'` has been tested successfully

> error message: `--no-mariadb-socket is DEPRECATED; use --mariadb-user-host-login-scope='%' (wildcard) or --mariadb-user-host-login-scope=, instead. The name of this option was misleading: it had nothing to do with sockets.`