### PR TITLE
Fix: correct site name correctly in backup and drop multiple site jobs

### DIFF
--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 
 ### erpnext
 
-![Version: 8.0.20](https://img.shields.io/badge/Version-8.0.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.4.0](https://img.shields.io/badge/AppVersion-v16.4.0-informational?style=flat-square)
+![Version: 8.0.24](https://img.shields.io/badge/Version-8.0.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.6.1](https://img.shields.io/badge/AppVersion-v16.6.1-informational?style=flat-square)
 
 Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 
@@ -99,7 +99,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | httproute.rules[0].matches[0].pathType | string | `"PathPrefix"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"frappe/erpnext"` |  |
-| image.tag | string | `"v16.4.0"` |  |
+| image.tag | string | `"v16.6.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 
 ### erpnext
 
-![Version: 8.0.40](https://img.shields.io/badge/Version-8.0.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.13.1](https://img.shields.io/badge/AppVersion-v16.13.1-informational?style=flat-square)
+![Version: 8.0.41](https://img.shields.io/badge/Version-8.0.41-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.13.2](https://img.shields.io/badge/AppVersion-v16.13.2-informational?style=flat-square)
 
 Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 
@@ -100,7 +100,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | httproute.rules[0].matches[0].pathType | string | `"PathPrefix"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"frappe/erpnext"` |  |
-| image.tag | string | `"v16.13.1"` |  |
+| image.tag | string | `"v16.13.2"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 
 ### erpnext
 
-![Version: 8.0.22](https://img.shields.io/badge/Version-8.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.5.0](https://img.shields.io/badge/AppVersion-v16.5.0-informational?style=flat-square)
+![Version: 8.0.40](https://img.shields.io/badge/Version-8.0.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.13.1](https://img.shields.io/badge/AppVersion-v16.13.1-informational?style=flat-square)
 
 Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 
@@ -100,7 +100,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | httproute.rules[0].matches[0].pathType | string | `"PathPrefix"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"frappe/erpnext"` |  |
-| image.tag | string | `"v16.5.0"` |  |
+| image.tag | string | `"v16.13.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/erpnext/templates/job-backup-multiple-sites.yaml
+++ b/erpnext/templates/job-backup-multiple-sites.yaml
@@ -28,7 +28,7 @@ spec:
         args:
           - >
             {{- range $site := .Values.jobs.backupMultipleSites.sites }}
-            bench --site={{ $site }} {{- if $.Values.jobs.backupMultipleSites.withFiles }} backup --with-files; {{- else }} backup; {{- end }}
+              bench --site={{ $site.name }} {{- if $.Values.jobs.backupMultipleSites.withFiles }} backup --with-files; {{- else }} backup; {{- end }}
             {{- end }}
         resources:
           {{- toYaml .Values.jobs.backupMultipleSites.resources | nindent 10 }}

--- a/erpnext/templates/job-drop-multiple-sites.yaml
+++ b/erpnext/templates/job-drop-multiple-sites.yaml
@@ -28,7 +28,7 @@ spec:
         args:
           - >
             {{- range $site := .Values.jobs.dropMultipleSites.sites }}
-              bench drop-site {{ $site }} --root-login=$DB_ROOT_USER --root-password=$DB_ROOT_PASSWORD --archived-sites-path=archived_sites --no-backup {{- if $.Values.jobs.dropMultipleSites.forced }} --force{{- end }};
+              bench drop-site {{ $site.name }} --root-login=$DB_ROOT_USER --root-password=$DB_ROOT_PASSWORD --archived-sites-path=archived_sites --no-backup {{- if $.Values.jobs.dropMultipleSites.forced }} --force{{- end }};
             {{- end }}
 
         env:


### PR DESCRIPTION
## Summary

This PR fixes an issue in the `backup-multiple-sites` and `drop-multiple-sites` Helm job templates where the full site map was being passed to the `--site` flag instead of the actual site name.

## Problem

The jobs iterate over:

```yaml
sites:
  - name: "frappe.helpdesk.local"
 ```
However, the template previously used:
```code
--site={{ $site }}
```
Since `$site` is a map (e.g., `map[name:frappe.helpdesk.local]`), the generated command became invalid:
```code
bench --site=map[name:frappe.helpdesk.local] backup
```
This caused the jobs to fail.

## Fix

Updated the templates to correctly reference:
``` code
--site={{ $site.name }}
```
This ensures the generated command is:
```code
bench --site=frappe.helpdesk.local backup
```

## The same correction has been applied to both:
- backup-multiple-sites
- drop-multiple-sites

## Validation
- Deployed the updated chart.
- Verified that backup and drop jobs now execute successfully.
- Confirmed correct --site argument in generated pod logs.