### PR TITLE
feat: add common pod labels support

### DIFF
--- a/erpnext/templates/_helpers.tpl
+++ b/erpnext/templates/_helpers.tpl
@@ -96,3 +96,12 @@ Gets the redis cache host name
 {{- define "erpnext.redisCacheHost" -}}
 {{ .Values.redisCacheHost }}
 {{- end -}}
+
+{{/*
+Common pod labels - only user-defined common pod labels
+*/}}
+{{- define "erpnext.commonPodLabels" -}}
+{{- if .Values.commonPodLabels }}
+{{- toYaml .Values.commonPodLabels }}
+{{- end }}
+{{- end -}}

--- a/erpnext/templates/deployment-gunicorn.yaml
+++ b/erpnext/templates/deployment-gunicorn.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-gunicorn
         app.kubernetes.io/instance: {{ .Release.Name }}-gunicorn
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/templates/deployment-nginx.yaml
+++ b/erpnext/templates/deployment-nginx.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-nginx
         app.kubernetes.io/instance: {{ .Release.Name }}-nginx
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/templates/deployment-scheduler.yaml
+++ b/erpnext/templates/deployment-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-scheduler
         app.kubernetes.io/instance: {{ .Release.Name }}-scheduler
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-socketio
         app.kubernetes.io/instance: {{ .Release.Name }}-socketio
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/templates/deployment-worker-default.yaml
+++ b/erpnext/templates/deployment-worker-default.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-worker-d
         app.kubernetes.io/instance: {{ .Release.Name }}-worker-d
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/templates/deployment-worker-long.yaml
+++ b/erpnext/templates/deployment-worker-long.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-worker-l
         app.kubernetes.io/instance: {{ .Release.Name }}-worker-l
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/templates/deployment-worker-short.yaml
+++ b/erpnext/templates/deployment-worker-short.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-worker-s
         app.kubernetes.io/instance: {{ .Release.Name }}-worker-s
         app.kubernetes.io/app: frappe
+        {{- include "erpnext.commonPodLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -16,6 +16,16 @@ externalRedis:
   cache: ""
   queue: ""
 
+# Common pod labels that will be applied to all deployments
+# These labels are in addition to the standard Kubernetes recommended labels
+# Example:
+# commonPodLabels:
+#   environment: production
+#   team: platform
+#   cost-center: engineering
+#   monitoring: enabled
+commonPodLabels: {}
+
 image:
   repository: frappe/erpnext
   tag: v16.8.0


### PR DESCRIPTION
This PR introduces **common pod labels support** for ERPNext deployments, allowing the same labels to be applied to **all pods across all deployments in a single Helm release**.
## What's included
- ✅ Add `commonPodLabels` helper template for user-defined pod labels
- ✅ Update all deployment templates to include common pod labels
- ✅ Add `commonPodLabels` configuration to values.yaml with examples
- ✅ Preserve all existing pod labels without modification
## Key Features
- **Universal Application**: Labels are automatically applied to all ERPNext deployments
- **Non-intrusive**: All existing pod labels remain completely untouched
- **Backwards Compatible**: Works with empty `{}` or missing `commonPodLabels` configuration
- **Flexible**: Supports any number of custom key-value label pairs
## Usage Example
```yaml
commonPodLabels:
  environment: production
  team: platform
  cost-center: engineering
  monitoring: enabled
  app-version: v16.8.0
```
Backward compatibility
- ✅ No existing values or workflows are broken
- ✅ All original pod labels preserved exactly as they were
- ✅ Upgrading users can opt in to common pod labels without changing current setups
- ✅ Works with empty configuration
Testing
All deployments (nginx, gunicorn, socketio, scheduler, workers) will now include:
- Existing labels: app.kubernetes.io/name, app.kubernetes.io/instance, app.kubernetes.io/app: frappe (untouched)
- Custom labels: Your common labels from values.commonPodLabels
Fixes common requirement for applying organization-wide labels to Kubernetes resources.