### PR TITLE
feat: Add podAnnotations support to deployment templates

### DIFF
--- a/erpnext/Chart.yaml
+++ b/erpnext/Chart.yaml
@@ -4,8 +4,8 @@ description: Kubernetes Helm Chart for the latest stable ERPNext branch
 icon: 
   https://raw.githubusercontent.com/frappe/erpnext/develop/erpnext/public/images/erpnext-logo.png
 type: application
-version: 8.0.54
-appVersion: v16.20.0
+version: 8.0.55
+appVersion: v16.20.1
 dependencies:
 - name: mariadb
   condition: mariadb.enabled,mariadb-subchart.enabled

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 
 ### erpnext
 
-![Version: 8.0.54](https://img.shields.io/badge/Version-8.0.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.20.0](https://img.shields.io/badge/AppVersion-v16.20.0-informational?style=flat-square)
+![Version: 8.0.55](https://img.shields.io/badge/Version-8.0.55-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.20.1](https://img.shields.io/badge/AppVersion-v16.20.1-informational?style=flat-square)
 
 Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 
@@ -100,7 +100,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | httproute.rules[0].matches[0].pathType | string | `"PathPrefix"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"frappe/erpnext"` |  |
-| image.tag | string | `"v16.20.0"` |  |
+| image.tag | string | `"v16.20.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -256,6 +256,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | nginx.livenessProbe.periodSeconds | int | `10` |  |
 | nginx.livenessProbe.tcpSocket.port | int | `8080` |  |
 | nginx.nodeSelector | object | `{}` |  |
+| nginx.podAnnotations | object | `{}` |  |
 | nginx.readinessProbe.initialDelaySeconds | int | `5` |  |
 | nginx.readinessProbe.periodSeconds | int | `10` |  |
 | nginx.readinessProbe.tcpSocket.port | int | `8080` |  |
@@ -304,6 +305,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | socketio.livenessProbe.periodSeconds | int | `10` |  |
 | socketio.livenessProbe.tcpSocket.port | int | `9000` |  |
 | socketio.nodeSelector | object | `{}` |  |
+| socketio.podAnnotations | object | `{}` |  |
 | socketio.readinessProbe.initialDelaySeconds | int | `5` |  |
 | socketio.readinessProbe.periodSeconds | int | `10` |  |
 | socketio.readinessProbe.tcpSocket.port | int | `9000` |  |
@@ -330,6 +332,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | worker.default.livenessProbe.override | bool | `false` |  |
 | worker.default.livenessProbe.probe | object | `{}` |  |
 | worker.default.nodeSelector | object | `{}` |  |
+| worker.default.podAnnotations | object | `{}` |  |
 | worker.default.readinessProbe.override | bool | `false` |  |
 | worker.default.readinessProbe.probe | object | `{}` |  |
 | worker.default.replicaCount | int | `1` |  |
@@ -352,6 +355,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | worker.gunicorn.livenessProbe.periodSeconds | int | `10` |  |
 | worker.gunicorn.livenessProbe.tcpSocket.port | int | `8000` |  |
 | worker.gunicorn.nodeSelector | object | `{}` |  |
+| worker.gunicorn.podAnnotations | object | `{}` |  |
 | worker.gunicorn.readinessProbe.initialDelaySeconds | int | `5` |  |
 | worker.gunicorn.readinessProbe.periodSeconds | int | `10` |  |
 | worker.gunicorn.readinessProbe.tcpSocket.port | int | `8000` |  |
@@ -373,6 +377,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | worker.long.livenessProbe.override | bool | `false` |  |
 | worker.long.livenessProbe.probe | object | `{}` |  |
 | worker.long.nodeSelector | object | `{}` |  |
+| worker.long.podAnnotations | object | `{}` |  |
 | worker.long.readinessProbe.override | bool | `false` |  |
 | worker.long.readinessProbe.probe | object | `{}` |  |
 | worker.long.replicaCount | int | `1` |  |
@@ -385,6 +390,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | worker.scheduler.livenessProbe.override | bool | `false` |  |
 | worker.scheduler.livenessProbe.probe | object | `{}` |  |
 | worker.scheduler.nodeSelector | object | `{}` |  |
+| worker.scheduler.podAnnotations | object | `{}` |  |
 | worker.scheduler.readinessProbe.override | bool | `false` |  |
 | worker.scheduler.readinessProbe.probe | object | `{}` |  |
 | worker.scheduler.replicaCount | int | `1` |  |
@@ -402,6 +408,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | worker.short.livenessProbe.override | bool | `false` |  |
 | worker.short.livenessProbe.probe | object | `{}` |  |
 | worker.short.nodeSelector | object | `{}` |  |
+| worker.short.podAnnotations | object | `{}` |  |
 | worker.short.readinessProbe.override | bool | `false` |  |
 | worker.short.readinessProbe.probe | object | `{}` |  |
 | worker.short.replicaCount | int | `1` |  |

--- a/erpnext/templates/deployment-gunicorn.yaml
+++ b/erpnext/templates/deployment-gunicorn.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-gunicorn
   template:
     metadata:
+      {{- with .Values.worker.gunicorn.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-gunicorn
         app.kubernetes.io/instance: {{ .Release.Name }}-gunicorn

--- a/erpnext/templates/deployment-nginx.yaml
+++ b/erpnext/templates/deployment-nginx.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-nginx
   template:
     metadata:
+      {{- with .Values.nginx.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-nginx
         app.kubernetes.io/instance: {{ .Release.Name }}-nginx

--- a/erpnext/templates/deployment-scheduler.yaml
+++ b/erpnext/templates/deployment-scheduler.yaml
@@ -12,6 +12,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-scheduler
   template:
     metadata:
+      {{- with .Values.worker.scheduler.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-scheduler
         app.kubernetes.io/instance: {{ .Release.Name }}-scheduler

--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-socketio
   template:
     metadata:
+      {{- with .Values.socketio.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-socketio
         app.kubernetes.io/instance: {{ .Release.Name }}-socketio

--- a/erpnext/templates/deployment-worker-default.yaml
+++ b/erpnext/templates/deployment-worker-default.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-worker-d
   template:
     metadata:
+      {{- with .Values.worker.default.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-worker-d
         app.kubernetes.io/instance: {{ .Release.Name }}-worker-d

--- a/erpnext/templates/deployment-worker-long.yaml
+++ b/erpnext/templates/deployment-worker-long.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-worker-l
   template:
     metadata:
+      {{- with .Values.worker.long.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-worker-l
         app.kubernetes.io/instance: {{ .Release.Name }}-worker-l

--- a/erpnext/templates/deployment-worker-short.yaml
+++ b/erpnext/templates/deployment-worker-short.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}-worker-s
   template:
     metadata:
+      {{- with .Values.worker.short.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "erpnext.name" . }}-worker-s
         app.kubernetes.io/instance: {{ .Release.Name }}-worker-s

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -22,6 +22,7 @@ image:
   pullPolicy: IfNotPresent
 
 nginx:
+  podAnnotations: {}
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -72,6 +73,7 @@ nginx:
 
 worker:
   gunicorn:
+    podAnnotations: {}
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -102,6 +104,7 @@ worker:
     sidecars: []
 
   default:
+    podAnnotations: {}
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -124,6 +127,7 @@ worker:
     sidecars: []
 
   short:
+    podAnnotations: {}
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -146,6 +150,7 @@ worker:
     sidecars: []
 
   long:
+    podAnnotations: {}
     replicaCount: 1
     autoscaling:
       enabled: false
@@ -168,6 +173,7 @@ worker:
     sidecars: []
 
   scheduler:
+    podAnnotations: {}
     replicaCount: 1
     resources: {}
     nodeSelector: {}
@@ -248,6 +254,7 @@ worker:
     timeoutSeconds: 5
 
 socketio:
+  podAnnotations: {}
   replicaCount: 1
   autoscaling:
     enabled: false

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -18,7 +18,7 @@ externalRedis:
 
 image:
   repository: frappe/erpnext
-  tag: v16.20.0
+  tag: v16.20.1
   pullPolicy: IfNotPresent
 
 nginx:


### PR DESCRIPTION
## Summary
- Add per-deployment `podAnnotations` values (defaulting to `{}`) applied to `spec.template.metadata.annotations` on each deployment template
- Enables integrations like Velero, Prometheus, Istio, and Vault Agent that read annotations from pods
- Each workload has its own field: `nginx`, `worker.gunicorn`, `worker.default`, `worker.short`, `worker.long`, `worker.scheduler`, and `socketio`
- Fully backwards compatible — empty default produces no change in rendered output

Closes #288