### PR TITLE
Feat/persistence logs subpath

### DIFF
--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -140,6 +140,18 @@ persistence:
 
 Make sure the PVC called `existing-sites` exists in the namespace.
 
+`persistence.logs` also supports `existingClaim`, together with an optional
+`subPath` so logs can share a PVC (e.g. the worker's) without the two
+volumes' contents mixing at the mount root:
+
+```yaml
+persistence:
+  logs:
+    enabled: true
+    existingClaim: existing-sites
+    subPath: logs-data
+```
+
 ### Access Modes
 
 Make following changes to custom-values.yaml:

--- a/erpnext/Chart.yaml
+++ b/erpnext/Chart.yaml
@@ -4,7 +4,7 @@ description: Kubernetes Helm Chart for the latest stable ERPNext branch
 icon: 
   https://raw.githubusercontent.com/frappe/erpnext/develop/erpnext/public/images/erpnext-logo.png
 type: application
-version: 8.0.46
+version: 8.0.47
 appVersion: v16.16.0
 dependencies:
 - name: mariadb

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -476,6 +476,18 @@ persistence:
 
 Make sure the PVC called `existing-sites` exists in the namespace.
 
+`persistence.logs` also supports `existingClaim`, together with an optional
+`subPath` so logs can share a PVC (e.g. the worker's) without the two
+volumes' contents mixing at the mount root:
+
+```yaml
+persistence:
+  logs:
+    enabled: true
+    existingClaim: existing-sites
+    subPath: logs-data
+```
+
 ### Access Modes
 
 Make following changes to custom-values.yaml:

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the ERPNext chart and t
 
 ### erpnext
 
-![Version: 8.0.55](https://img.shields.io/badge/Version-8.0.55-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.20.1](https://img.shields.io/badge/AppVersion-v16.20.1-informational?style=flat-square)
+![Version: 8.0.76](https://img.shields.io/badge/Version-8.0.76-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v16.32.3](https://img.shields.io/badge/AppVersion-v16.32.3-informational?style=flat-square)
 
 Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 
@@ -100,7 +100,7 @@ Kubernetes Helm Chart for ERPNext and Frappe Framework Apps.
 | httproute.rules[0].matches[0].pathType | string | `"PathPrefix"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"frappe/erpnext"` |  |
-| image.tag | string | `"v16.20.1"` |  |
+| image.tag | string | `"v16.32.3"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/erpnext/templates/deployment-gunicorn.yaml
+++ b/erpnext/templates/deployment-gunicorn.yaml
@@ -45,6 +45,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/deployment-gunicorn.yaml
+++ b/erpnext/templates/deployment-gunicorn.yaml
@@ -47,6 +47,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.worker.gunicorn.service.port }}

--- a/erpnext/templates/deployment-nginx.yaml
+++ b/erpnext/templates/deployment-nginx.yaml
@@ -77,6 +77,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           {{- if .Values.nginx.config }}
           - name: nginx-config
             mountPath: /etc/nginx/conf.d

--- a/erpnext/templates/deployment-scheduler.yaml
+++ b/erpnext/templates/deployment-scheduler.yaml
@@ -58,6 +58,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/deployment-scheduler.yaml
+++ b/erpnext/templates/deployment-scheduler.yaml
@@ -60,6 +60,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       {{- if .Values.worker.scheduler.sidecars }}
         {{- toYaml .Values.worker.scheduler.sidecars | nindent 8 }}
       {{- end }}

--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -47,6 +47,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/erpnext/templates/deployment-socketio.yaml
+++ b/erpnext/templates/deployment-socketio.yaml
@@ -45,6 +45,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/deployment-worker-default.yaml
+++ b/erpnext/templates/deployment-worker-default.yaml
@@ -64,6 +64,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       {{- if .Values.worker.default.sidecars }}
         {{- toYaml .Values.worker.default.sidecars | nindent 8 }}
       {{- end }}

--- a/erpnext/templates/deployment-worker-default.yaml
+++ b/erpnext/templates/deployment-worker-default.yaml
@@ -62,6 +62,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/deployment-worker-long.yaml
+++ b/erpnext/templates/deployment-worker-long.yaml
@@ -64,6 +64,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       {{- if .Values.worker.long.sidecars }}
         {{- toYaml .Values.worker.long.sidecars | nindent 8 }}
       {{- end }}

--- a/erpnext/templates/deployment-worker-long.yaml
+++ b/erpnext/templates/deployment-worker-long.yaml
@@ -62,6 +62,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/deployment-worker-short.yaml
+++ b/erpnext/templates/deployment-worker-short.yaml
@@ -64,6 +64,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       {{- if .Values.worker.short.sidecars }}
         {{- toYaml .Values.worker.short.sidecars | nindent 8 }}
       {{- end }}

--- a/erpnext/templates/deployment-worker-short.yaml
+++ b/erpnext/templates/deployment-worker-short.yaml
@@ -62,6 +62,9 @@ spec:
           volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-backup-multiple-sites.yaml
+++ b/erpnext/templates/job-backup-multiple-sites.yaml
@@ -39,6 +39,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-backup-multiple-sites.yaml
+++ b/erpnext/templates/job-backup-multiple-sites.yaml
@@ -37,6 +37,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-backup.yaml
+++ b/erpnext/templates/job-backup.yaml
@@ -40,6 +40,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-backup.yaml
+++ b/erpnext/templates/job-backup.yaml
@@ -38,6 +38,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-clear-cache.yaml
+++ b/erpnext/templates/job-clear-cache.yaml
@@ -53,6 +53,9 @@ spec:
           volumeMounts:
             - name: sites-dir
               mountPath: /home/frappe/frappe-bench/sites
+              {{- if .Values.persistence.worker.subPath }}
+              subPath: {{ .Values.persistence.worker.subPath }}
+              {{- end }}
       volumes:
         - name: sites-dir
           {{- if .Values.persistence.worker.enabled }}

--- a/erpnext/templates/job-configure-bench.yaml
+++ b/erpnext/templates/job-configure-bench.yaml
@@ -34,6 +34,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}
@@ -127,6 +130,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-configure-bench.yaml
+++ b/erpnext/templates/job-configure-bench.yaml
@@ -36,6 +36,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       {{- end }}
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
@@ -126,6 +129,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-create-multiple-sites.yaml
+++ b/erpnext/templates/job-create-multiple-sites.yaml
@@ -82,6 +82,9 @@ spec:
           volumeMounts:
             - name: sites-dir
               mountPath: /home/frappe/frappe-bench/sites
+              {{- if .Values.persistence.worker.subPath }}
+              subPath: {{ .Values.persistence.worker.subPath }}
+              {{- end }}
       containers:
       - name: create-site
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -196,6 +199,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-create-multiple-sites.yaml
+++ b/erpnext/templates/job-create-multiple-sites.yaml
@@ -198,6 +198,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -82,6 +82,9 @@ spec:
           volumeMounts:
             - name: sites-dir
               mountPath: /home/frappe/frappe-bench/sites
+              {{- if .Values.persistence.worker.subPath }}
+              subPath: {{ .Values.persistence.worker.subPath }}
+              {{- end }}
       containers:
       - name: create-site
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -193,6 +196,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-create-site.yaml
+++ b/erpnext/templates/job-create-site.yaml
@@ -195,6 +195,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-drop-multiple-sites.yaml
+++ b/erpnext/templates/job-drop-multiple-sites.yaml
@@ -98,6 +98,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-drop-multiple-sites.yaml
+++ b/erpnext/templates/job-drop-multiple-sites.yaml
@@ -96,6 +96,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-drop-site.yaml
+++ b/erpnext/templates/job-drop-site.yaml
@@ -97,6 +97,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-drop-site.yaml
+++ b/erpnext/templates/job-drop-site.yaml
@@ -95,6 +95,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-fix-volume-permission.yaml
+++ b/erpnext/templates/job-fix-volume-permission.yaml
@@ -39,6 +39,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-fix-volume-permission.yaml
+++ b/erpnext/templates/job-fix-volume-permission.yaml
@@ -37,6 +37,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-migrate-multiple-sites.yaml
+++ b/erpnext/templates/job-migrate-multiple-sites.yaml
@@ -39,6 +39,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-migrate-multiple-sites.yaml
+++ b/erpnext/templates/job-migrate-multiple-sites.yaml
@@ -41,6 +41,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/templates/job-migrate-site.yaml
+++ b/erpnext/templates/job-migrate-site.yaml
@@ -40,6 +40,9 @@ spec:
         volumeMounts:
           - name: sites-dir
             mountPath: /home/frappe/frappe-bench/sites
+            {{- if .Values.persistence.worker.subPath }}
+            subPath: {{ .Values.persistence.worker.subPath }}
+            {{- end }}
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
             {{- if .Values.persistence.logs.subPath }}

--- a/erpnext/templates/job-migrate-site.yaml
+++ b/erpnext/templates/job-migrate-site.yaml
@@ -42,6 +42,9 @@ spec:
             mountPath: /home/frappe/frappe-bench/sites
           - name: logs
             mountPath: /home/frappe/frappe-bench/logs
+            {{- if .Values.persistence.logs.subPath }}
+            subPath: {{ .Values.persistence.logs.subPath }}
+            {{- end }}
       restartPolicy: Never
       volumes:
         - name: sites-dir

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -288,6 +288,10 @@ persistence:
     # Container based log search and analytics stack recommended
     enabled: false
     # existingClaim: ""
+    # Subpath inside the PVC referenced by existingClaim to mount logs
+    # into. Lets logs share a PVC (e.g. the worker's) without the two
+    # volumes' contents mixing at the mount root.
+    # subPath: ""
     size: 8Gi
     # storageClass: "nfs"
     accessModes:

--- a/erpnext/values.yaml
+++ b/erpnext/values.yaml
@@ -280,6 +280,10 @@ persistence:
   worker:
     enabled: true
     # existingClaim: ""
+    # Subpath inside the PVC referenced by existingClaim to mount sites
+    # into. Lets the worker share a PVC with another volume without the
+    # two volumes' contents mixing at the mount root.
+    # subPath: ""
     size: 8Gi
     # storageClass: "nfs"
     accessModes:


### PR DESCRIPTION
## Problem

`persistence.worker` and `persistence.logs` both support `existingClaim`, which lets you point either volume at a PVC that already exists instead of having the chart provision a new one. This is useful whenever you want two of the chart's volumes to live on the *same* underlying PVC instead of two separate ones — for example, on storage backends that bill or provision per-PVC with a large minimum size (e.g. Azure Files "Provisioned v2" shares have a 32Gi minimum regardless of the requested `size`), where provisioning a second PVC just for `logs` (which typically holds a few MB of data) doubles the storage cost for no real benefit.

The problem is that neither volume's mount supports `subPath`. Both `sites-dir` (worker) and `logs` are mounted at the *root* of whatever PVC they're bound to. So if you set `persistence.logs.existingClaim` to the same PVC already used by `persistence.worker`, both volumes end up writing into the exact same root directory — `logs`'s content lands mixed in with the worker's `sites-dir` tree (`common_site_config.json`, `apps.txt`, per-site folders, etc.) instead of living in its own subdirectory. There's no way to point two volumes at one PVC without their contents colliding.

## Change

Adds an optional `subPath` field to both `persistence.worker` and `persistence.logs`, wired into the corresponding `volumeMounts` entry wherever each volume is mounted (all `deployment-*.yaml` and `job-*.yaml` templates that reference `sites-dir` and/or `logs` — 18 files in total, one repeated one-line pattern per volume type). When set, it's passed straight through as `subPath` on the mount; when unset (the default), the field is omitted entirely and rendering is byte-for-byte identical to today.

This mirrors the pattern the `valkey` subchart (`dataStorage.persistentVolumeClaimName` + `dataStorage.subPath`) already uses for exactly this purpose, so it's consistent with prior art already vendored in this chart.

Example usage — worker and logs sharing one PVC, isolated by subpath:

\`\`\`yaml
persistence:
  worker:
    existingClaim: my-app-erpnext
  logs:
    enabled: true
    existingClaim: my-app-erpnext
    subPath: logs-data
\`\`\`

## Backward compatibility

Fully additive and opt-in. `subPath` defaults to unset, and the template guards it with `{{- if .Values.persistence.worker.subPath }}` / `{{- if .Values.persistence.logs.subPath }}`, so existing values files render identically to before this change — confirmed with `helm template` diffs against the default values.

## Testing

- `helm template` with and without `subPath` set, for both `persistence.worker` and `persistence.logs` — confirmed the mount only gains a `subPath` line when the value is set, otherwise output is unchanged.
- `helm lint` passes.
- Live cluster verification (Kubernetes, Azure Files RWX PVC): two pods mounting the same PVC at different paths with different `subPath` values only ever see their own file, never each other's — and a third pod mounting the PVC without `subPath` sees both subdirectories cleanly separated at the root, confirming no content mixing. Also verified that data written under a `subPath` survives deleting and recreating the pod, i.e. it's genuinely persisted on the PVC rather than behaving like `emptyDir`.
